### PR TITLE
Fix invalid deployment strategy placement

### DIFF
--- a/operator/k8s/operator/operator.yaml
+++ b/operator/k8s/operator/operator.yaml
@@ -21,13 +21,13 @@ spec:
   selector:
     matchLabels:
       app: gerrit-operator
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
         app: gerrit-operator
     spec:
-      strategy:
-        type: Recreate
       serviceAccountName: gerrit-operator
       containers:
       - name: operator


### PR DESCRIPTION
The strategy type was defined inside the pod specification rather than the deployment specification where it is expected.

Moved it into the correct scope.

# Important Notice

Patch submission and review is done through
[Gerrit Code Review](https://gerrit-review.googlesource.com).
Unfortunately we cannot pull your code as a Pull Request.

__NO REVIEWS OR DISCUSSIONS will happen on GitHub__, all the
[code collaboration](../Documentation/developer-guide.md)
will take place on Gerrit.
